### PR TITLE
Feat/option to EnableShortTerm & EnableFuzz

### DIFF
--- a/deck_test.go
+++ b/deck_test.go
@@ -20,7 +20,7 @@ import (
 	"os"
 	"testing"
 
-	"github.com/open-spaced-repetition/go-fsrs/v2"
+	"github.com/open-spaced-repetition/go-fsrs/v3"
 )
 
 func TestDeck(t *testing.T) {

--- a/fsrs_store_test.go
+++ b/fsrs_store_test.go
@@ -24,7 +24,7 @@ import (
 
 	"github.com/88250/gulu"
 
-	"github.com/open-spaced-repetition/go-fsrs/v2"
+	"github.com/open-spaced-repetition/go-fsrs/v3"
 )
 
 const (
@@ -40,6 +40,7 @@ func TestFSRSStore(t *testing.T) {
 
 	store := NewFSRSStore("test-store", storePath, requestRetention, maximumInterval, weights)
 	p := fsrs.DefaultParam()
+	scheduler := *fsrs.NewFSRS(p)
 	start := time.Now()
 	repeatTime := start
 	ids := map[string]bool{}
@@ -60,7 +61,7 @@ func TestFSRSStore(t *testing.T) {
 		ids[id] = true
 
 		for j := 0; j < 10; j++ {
-			schedulingInfo := p.Repeat(c, repeatTime)
+			schedulingInfo := scheduler.Repeat(c, repeatTime)
 			c = schedulingInfo[fsrs.Hard].Card
 			repeatTime = c.Due
 		}

--- a/go.mod
+++ b/go.mod
@@ -6,7 +6,7 @@ toolchain go1.23.0
 
 require (
 	github.com/88250/gulu v1.2.3-0.20240612035750-c9cf5f7a4d02
-	github.com/open-spaced-repetition/go-fsrs/v2 v2.0.1
+	github.com/open-spaced-repetition/go-fsrs/v3 v3.1.0
 	github.com/siyuan-note/filelock v0.0.0-20240724034355-d1ed7bf21d04
 	github.com/siyuan-note/logging v0.0.0-20240505035402-6430d57006a2
 	github.com/vmihailenco/msgpack/v5 v5.4.1

--- a/go.sum
+++ b/go.sum
@@ -31,8 +31,8 @@ github.com/onsi/ginkgo/v2 v2.20.1 h1:YlVIbqct+ZmnEph770q9Q7NVAz4wwIiVNahee6JyUzo
 github.com/onsi/ginkgo/v2 v2.20.1/go.mod h1:lG9ey2Z29hR41WMVthyJBGUBcBhGOtoPF2VFMvBXFCI=
 github.com/onsi/gomega v1.34.1 h1:EUMJIKUjM8sKjYbtxQI9A4z2o+rruxnzNvpknOXie6k=
 github.com/onsi/gomega v1.34.1/go.mod h1:kU1QgUvBDLXBJq618Xvm2LUX6rSAfRaFRTcdOeDLwwY=
-github.com/open-spaced-repetition/go-fsrs/v2 v2.0.1 h1:ODpQGZqZNsKqAF4/WUdRtfuNtwDIfI6Xj3cSznxk0g0=
-github.com/open-spaced-repetition/go-fsrs/v2 v2.0.1/go.mod h1:Ry+MLx079nUXwSbYm+OYLK9pQ9yu0cCLWSo3N4H5ZBI=
+github.com/open-spaced-repetition/go-fsrs/v3 v3.1.0 h1:wsNqYC0poLo1+4c9T4AoYvsPMpyTIjYpf2PpWbgJf7k=
+github.com/open-spaced-repetition/go-fsrs/v3 v3.1.0/go.mod h1:zTtQIk3kOO9kweg5zJAgbdwBXR2HBPsDN0k6AxmTpzY=
 github.com/pingcap/errors v0.11.4 h1:lFuQV/oaUMGcD2tqt+01ROSmJs75VG1ToEOkZIZ4nE4=
 github.com/pingcap/errors v0.11.4/go.mod h1:Oi8TUi2kEtXXLMJk9l1cGmz20kV3TaQ0usTwv5KuLY8=
 github.com/pkg/errors v0.9.1 h1:FEBLx1zS214owpjy7qsBeixbURkuhQAwrK5UwLGTwt4=


### PR DESCRIPTION
go-fsrs 那边做了大重构，增加了 EnableShortTerm 和 EnableFuzz 两个选项。

EnableShortTerm 默认开启，保持和以前一样的行为。如果关闭，用户将不会收到短于 1 天的间隔，适合自己写卡片、终身学习。

EnableFuzz 默认关闭，保持和以前一样的行为。如果开启，复习间隔将会有一定的随机化，防止卡片都出现在同一天。

思源这边可以看看要不要加一下配置选项，我不太懂怎么弄，所以这个 PR 我就只把接口改了的地方升级了一下。